### PR TITLE
refactor/#30 도메인 계층 분리 및 강의 상세조회 응답 필드 추가 

### DIFF
--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/lecture/presentation/response/LectureDetailResponse.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/lecture/presentation/response/LectureDetailResponse.java
@@ -1,18 +1,31 @@
 package goorm.saerojinro.api.lecture.presentation.response;
 
+import goorm.saerojinro.common.domain.Category;
 import goorm.saerojinro.domain.lecture.domain.Lecture;
+import goorm.saerojinro.domain.user.domain.User;
 import lombok.Builder;
+
+import java.time.LocalDateTime;
 
 @Builder
 public record LectureDetailResponse(
 	String title,
-	String contents
-	// TODO 강연자 세부 정보 ?
+	User speaker,
+	String contents,
+	Category category,
+	LocalDateTime startTime,
+	LocalDateTime endTime,
+	String location
 ) {
 	public static LectureDetailResponse from(Lecture lecture) {
 		return LectureDetailResponse.builder()
 			.title(lecture.getTitle())
+			.speaker(lecture.getSpeaker())
 			.contents(lecture.getContents())
+			.category(lecture.getCategory())
+			.startTime(lecture.getStartTime())
+			.endTime(lecture.getEndTime())
+			.location(lecture.getLocation())
 			.build();
 	}
 }

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/lecture/application/LectureCommandService.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/lecture/application/LectureCommandService.java
@@ -4,28 +4,19 @@ import goorm.saerojinro.common.domain.Category;
 import goorm.saerojinro.domain.lecture.domain.Lecture;
 import goorm.saerojinro.domain.lecture.domain.LectureRepository;
 import goorm.saerojinro.domain.user.domain.User;
-import goorm.saerojinro.domain.user.domain.UserRepository;
-import goorm.saerojinro.domain.user.exception.InvalidUserRoleException;
-import goorm.saerojinro.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
-import static goorm.saerojinro.common.domain.BaseRole.SPEAKER;
 
 @Service
 @RequiredArgsConstructor
 public class LectureCommandService {
 	private final LectureRepository lectureRepository;
-	private final UserRepository userRepository;
 
-	public Lecture createLecture(Long speakerId, String title, String contents, Long maxCapacity,LocalDateTime startTime, LocalDateTime endTime, String location, Category category) {
-		User user = userRepository.findById(speakerId).orElseThrow(UserNotFoundException::new);
-		if (user.getRole() != SPEAKER) {
-			throw new InvalidUserRoleException();
-		}
-		Lecture lecture = Lecture.createLecture(user, title, contents, maxCapacity, startTime, endTime, location, category);
+	public Lecture createLecture(User speaker, String title, String contents, Long maxCapacity, LocalDateTime startTime, LocalDateTime endTime, String location, Category category) {
+		Lecture lecture = Lecture.createLecture(speaker, title, contents, maxCapacity, startTime, endTime, location, category);
 		return lectureRepository.save(lecture);
 	}
 }

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/application/UserQueryService.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/application/UserQueryService.java
@@ -22,10 +22,13 @@ public class UserQueryService {
 
 	public User login(String email, String password) {
 		User user = getByEmail(email);
-		if(!user.isPasswordMatched(password, bCryptPasswordEncoder)) {
+		if (!user.isPasswordMatched(password, bCryptPasswordEncoder)) {
 			throw new InvalidPasswordException();
 		}
-
 		return user;
+	}
+
+	public User findById(Long userId) {
+		return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 	}
 }

--- a/saerojinro-domain/src/testFixtures/java/lecture/application/LectureCommandServiceTest.java
+++ b/saerojinro-domain/src/testFixtures/java/lecture/application/LectureCommandServiceTest.java
@@ -23,7 +23,6 @@ public class LectureCommandServiceTest {
 	private FakeLectureRepository lectureRepository;
 	private FakeUserRepository userRepository;
 
-	private static final Long VALID_SPEAKER_ID = 1L;
 	private static final String TITLE = "Lecture Title";
 	private static final String CONTENTS = "Lecture Contents";
 	private static final Long MAX_CAPACITY = 100L;
@@ -34,8 +33,8 @@ public class LectureCommandServiceTest {
 	private static final LectureStatus EXPECTED_STATUS = LectureStatus.PENDING_APPROVAL;
 
 	private static final User VALID_SPEAKER = User.builder()
-		.id(VALID_SPEAKER_ID)
-		.name("Test Speaker")
+		.id(1L)
+		.name("Speaker")
 		.role(SPEAKER)
 		.build();
 
@@ -43,7 +42,7 @@ public class LectureCommandServiceTest {
 	void setUp() {
 		lectureRepository = new FakeLectureRepository();
 		userRepository = new FakeUserRepository();
-		lectureCommandService = new LectureCommandService(lectureRepository, userRepository);
+		lectureCommandService = new LectureCommandService(lectureRepository);
 
 		userRepository.save(VALID_SPEAKER);
 	}
@@ -53,7 +52,7 @@ public class LectureCommandServiceTest {
 	void createLecture_success() {
 		// when
 		Lecture createdLecture = lectureCommandService.createLecture(
-			VALID_SPEAKER_ID, TITLE, CONTENTS, MAX_CAPACITY, START_TIME, END_TIME, LOCATION, CATEGORY
+			VALID_SPEAKER, TITLE, CONTENTS, MAX_CAPACITY, START_TIME, END_TIME, LOCATION, CATEGORY
 		);
 
 		// then
@@ -68,35 +67,6 @@ public class LectureCommandServiceTest {
 		assertEquals(EXPECTED_STATUS, createdLecture.getLectureStatus());
 
 		assertNotNull(createdLecture.getSpeaker(), "강연자 정보는 null이면 안 됩니다.");
-		assertEquals(VALID_SPEAKER_ID, createdLecture.getSpeaker().getId());
-	}
-
-	@Test
-	@DisplayName("존재하지 않는 강연자 ID로 강의를 생성하면 예외가 발생한다")
-	void createLecture_userNotFound() {
-		Long invalidSpeakerId = 999L;
-		assertThrows(UserNotFoundException.class, () ->
-			lectureCommandService.createLecture(
-				invalidSpeakerId, TITLE, CONTENTS, MAX_CAPACITY, START_TIME, END_TIME, LOCATION, CATEGORY
-			)
-		);
-	}
-
-	@Test
-	@DisplayName("강연자 역할이 아닌 사용자가 강의 생성 요청 시 예외가 발생한다")
-	void createLecture_invalidUserRole() {
-		User nonSpeaker = User.builder()
-			.id(2L)
-			.name("Not a Speaker")
-			.role(ATTENDEE)
-			.build();
-		userRepository.save(nonSpeaker);
-
-		Long speakerId = 2L;
-		assertThrows(InvalidUserRoleException.class, () ->
-			lectureCommandService.createLecture(
-				speakerId, TITLE, CONTENTS, MAX_CAPACITY, START_TIME, END_TIME, LOCATION, CATEGORY
-			)
-		);
+		assertEquals(VALID_SPEAKER.getId(), createdLecture.getSpeaker().getId());
 	}
 }

--- a/saerojinro-speaker/src/main/java/goorm/saerojinro/speaker/api/SpeakerLectureFacade.java
+++ b/saerojinro-speaker/src/main/java/goorm/saerojinro/speaker/api/SpeakerLectureFacade.java
@@ -2,6 +2,8 @@ package goorm.saerojinro.speaker.api;
 
 import goorm.saerojinro.domain.lecture.application.LectureCommandService;
 import goorm.saerojinro.domain.lecture.domain.Lecture;
+import goorm.saerojinro.domain.user.application.UserQueryService;
+import goorm.saerojinro.domain.user.domain.User;
 import goorm.saerojinro.speaker.presentation.request.LectureCreateRequest;
 import goorm.saerojinro.speaker.presentation.response.LectureCreateResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +13,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SpeakerLectureFacade {
 	private final LectureCommandService lectureService;
+	private final UserQueryService userQueryService;
 
 	public LectureCreateResponse createLecture(long speakerId, LectureCreateRequest request) {
+		User speaker = userQueryService.findById(speakerId);
 		Lecture lecture = lectureService.createLecture(
-			speakerId,
+			speaker,
 			request.title(),
 			request.contents(),
 			request.maxCapacity(),

--- a/saerojinro-speaker/src/main/java/goorm/saerojinro/speaker/api/SpeakerLectureFacade.java
+++ b/saerojinro-speaker/src/main/java/goorm/saerojinro/speaker/api/SpeakerLectureFacade.java
@@ -16,7 +16,7 @@ public class SpeakerLectureFacade {
 	private final UserQueryService userQueryService;
 
 	public LectureCreateResponse createLecture(long speakerId, LectureCreateRequest request) {
-		User speaker = userQueryService.findById(speakerId);
+		User speaker = userQueryService.getById(speakerId);
 		Lecture lecture = lectureService.createLecture(
 			speaker,
 			request.title(),


### PR DESCRIPTION
## ⚡️ 관련 이슈
> 관련 있는 이슈를 태그해주세요.
- #30 

## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.

- LectureCommandService에서 직접 UserRepository를 호출하여 강연자(User) 정보를 조회하던 부분을 제거하고, 대신 UserQueryService를 통해 조회하도록 변경하였습니다.
- 이를 통해 강의 도메인은 사용자 조회 로직에 의존하지 않고, 강의 생성 로직에 집중할 수 있게 되었으며, 인프라 계층과의 의존성이 분리되었습니다.

강의 
## 🗣To Reviewer
> 의논이나 고려해야하는 내용을 작성해 주세요.

- LectureCommandService는 이제 UserQueryService로부터 이미 조회된 User 객체를 받아 강의 생성에만 집중합니다.
- 추가로 강의 상세 조회 필드에 유저, 카테고리, 시간 장소를 추가하였습니다

## 🌁 Screenshot
> (없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.