### PR TITLE
feature/#28 알림 전송을 위한 로직 추가 작성 및 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ subprojects {
         implementation 'io.jsonwebtoken:jjwt:0.9.1'
         implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
+        testFixturesImplementation 'org.springframework.boot:spring-boot-starter-web'
         testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'
         testFixturesImplementation 'org.springframework.security:spring-security-test'
         testFixturesRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -56,7 +56,6 @@ private excludedClassFilesForReport(classDirectories) {
                         "goorm/saerojinro/admin/SaerojinroAdminApplication.class",
                         "goorm/saerojinro/auth/SaerojinroAuthApplication.class",
                         "goorm/saerojinro/speaker/SaerojinroSpeakerApplication.class",
-                        "goorm/saerojinro/api/notification/application/NotificationFacade.class",
                 ])
             })
     )

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
@@ -4,7 +4,6 @@ import goorm.saerojinro.api.notification.presentation.exception.EmitterNotFoundE
 import goorm.saerojinro.api.notification.presentation.request.NotificationSendRequest;
 import goorm.saerojinro.api.notification.presentation.response.NotificationSendResponse;
 import goorm.saerojinro.api.notification.presentation.response.ReceivedNotificationListResponse;
-import goorm.saerojinro.domain.lecture.application.LectureQueryService;
 import goorm.saerojinro.domain.notification.application.NotificationCommandService;
 import goorm.saerojinro.domain.notification.application.NotificationQueryService;
 import goorm.saerojinro.domain.notification.domain.EmitterRepository;
@@ -33,12 +32,12 @@ public class NotificationFacade {
 		return emitterRepository.save(user.getId(), emitter);
 	}
 
-	public void sendNotificationByLectureIdWithRequest(Long lectureId, NotificationSendRequest request) {
+	public void sendNotificationByLectureId(Long lectureId, NotificationSendRequest request) {
 		// TODO lectureId -> 예약 -> 예약한 유저 리스트 -> iteration -> sendNotificationWithRequest
 	}
 
 	@Transactional
-	public void sendNotificationWithRequest(Long receiverId, NotificationSendRequest request) {
+	public void sendNotificationByReceiverId(Long receiverId, NotificationSendRequest request) {
 		Notification notification = Notification.createNotification(
 			userQueryService.getById(receiverId),
 			request.title(),

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
@@ -8,6 +8,8 @@ import goorm.saerojinro.domain.notification.application.NotificationCommandServi
 import goorm.saerojinro.domain.notification.application.NotificationQueryService;
 import goorm.saerojinro.domain.notification.domain.EmitterRepository;
 import goorm.saerojinro.domain.notification.domain.Notification;
+import goorm.saerojinro.domain.reservation.application.ReservationQueryService;
+import goorm.saerojinro.domain.reservation.domain.Reservation;
 import goorm.saerojinro.domain.user.application.UserQueryService;
 import goorm.saerojinro.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ public class NotificationFacade {
 	private final NotificationQueryService notificationQueryService;
 	private final EmitterRepository emitterRepository;
 	private final UserQueryService userQueryService;
+	private final ReservationQueryService reservationQueryService;
 
 	public SseEmitter subscribe() {
 		User user = userQueryService.me();
@@ -32,8 +35,13 @@ public class NotificationFacade {
 		return emitterRepository.save(user.getId(), emitter);
 	}
 
+	@Transactional
 	public void sendNotificationByLectureId(Long lectureId, NotificationSendRequest request) {
-		// TODO lectureId -> 예약 -> 예약한 유저 리스트 -> iteration -> sendNotificationWithRequest
+		List<Reservation> reservationList = reservationQueryService.getAllByLectureId(lectureId);
+		for (Reservation reservation : reservationList) {
+			Long receiverId = reservation.getUser().getId();
+			sendNotificationByReceiverId(receiverId, request);
+		}
 	}
 
 	@Transactional

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
@@ -8,6 +8,7 @@ import goorm.saerojinro.domain.notification.application.NotificationCommandServi
 import goorm.saerojinro.domain.notification.application.NotificationQueryService;
 import goorm.saerojinro.domain.notification.domain.EmitterRepository;
 import goorm.saerojinro.domain.notification.domain.Notification;
+import goorm.saerojinro.domain.user.application.UserQueryService;
 import goorm.saerojinro.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,23 +24,26 @@ public class NotificationFacade {
 	private final NotificationCommandService notificationCommandService;
 	private final NotificationQueryService notificationQueryService;
 	private final EmitterRepository emitterRepository;
+	private final UserQueryService userQueryService;
 
 	public SseEmitter subscribe() {
-		// TODO 현재 로그인한 유저 가져오기
-		User user = User.builder().id(1L).build();
+		User user = userQueryService.me();
 		SseEmitter emitter = new SseEmitter();
 		return emitterRepository.save(user.getId(), emitter);
 	}
 
 	public void sendNotificationByLectureIdWithRequest(Long lectureId, NotificationSendRequest request) {
-		// TODO lectureId -> lecture -> 예약 -> 예약한 유저 리스트 -> iteration -> sendNotificationWithRequest
+		// TODO lectureId -> 예약 -> 예약한 유저 리스트 -> iteration -> sendNotificationWithRequest
+
+
+
 	}
 
 	@Transactional
 	public void sendNotificationWithRequest(Long receiverId, NotificationSendRequest request) {
 		Notification notification = Notification.createNotification(
 			// TODO userService에서 아이디로 조회
-			User.builder().id(receiverId).build(),
+			userQueryService.findById(receiverId),
 			request.title(),
 			request.contents()
 		);
@@ -85,8 +89,7 @@ public class NotificationFacade {
 	@Transactional(readOnly = true)
 	public ReceivedNotificationListResponse myNotification() {
 		// TODO 현재 로그인한 유저 가져오기
-		User user = User.builder().id(1L).build();
-
+		User user = userQueryService.me();
 		List<Notification> notificationList = notificationQueryService.findByUserId(user.getId());
 		return ReceivedNotificationListResponse.from(notificationList);
 	}

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
@@ -4,6 +4,7 @@ import goorm.saerojinro.api.notification.presentation.exception.EmitterNotFoundE
 import goorm.saerojinro.api.notification.presentation.request.NotificationSendRequest;
 import goorm.saerojinro.api.notification.presentation.response.NotificationSendResponse;
 import goorm.saerojinro.api.notification.presentation.response.ReceivedNotificationListResponse;
+import goorm.saerojinro.domain.lecture.application.LectureQueryService;
 import goorm.saerojinro.domain.notification.application.NotificationCommandService;
 import goorm.saerojinro.domain.notification.application.NotificationQueryService;
 import goorm.saerojinro.domain.notification.domain.EmitterRepository;
@@ -34,17 +35,12 @@ public class NotificationFacade {
 
 	public void sendNotificationByLectureIdWithRequest(Long lectureId, NotificationSendRequest request) {
 		// TODO lectureId -> 예약 -> 예약한 유저 리스트 -> iteration -> sendNotificationWithRequest
-
-
-
 	}
 
 	@Transactional
 	public void sendNotificationWithRequest(Long receiverId, NotificationSendRequest request) {
 		Notification notification = Notification.createNotification(
-			// TODO userService에서 아이디로 조회
-//			userQueryService.findById(receiverId),
-			User.builder().id(1L).build(),
+			userQueryService.getById(receiverId),
 			request.title(),
 			request.contents()
 		);
@@ -89,7 +85,6 @@ public class NotificationFacade {
 
 	@Transactional(readOnly = true)
 	public ReceivedNotificationListResponse myNotification() {
-		// TODO 현재 로그인한 유저 가져오기
 		User user = userQueryService.me();
 		List<Notification> notificationList = notificationQueryService.findByUserId(user.getId());
 		return ReceivedNotificationListResponse.from(notificationList);

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
@@ -43,7 +43,8 @@ public class NotificationFacade {
 	public void sendNotificationWithRequest(Long receiverId, NotificationSendRequest request) {
 		Notification notification = Notification.createNotification(
 			// TODO userService에서 아이디로 조회
-			userQueryService.findById(receiverId),
+//			userQueryService.findById(receiverId),
+			User.builder().id(1L).build(),
 			request.title(),
 			request.contents()
 		);

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/application/NotificationFacade.java
@@ -31,8 +31,7 @@ public class NotificationFacade {
 
 	public SseEmitter subscribe() {
 		User user = userQueryService.me();
-		SseEmitter emitter = new SseEmitter();
-		return emitterRepository.save(user.getId(), emitter);
+		return emitterRepository.save(user.getId());
 	}
 
 	@Transactional

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/presentation/NotificationControllerImpl.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/presentation/NotificationControllerImpl.java
@@ -47,7 +47,7 @@ public class NotificationControllerImpl implements NotificationController {
 	public ResponseEntity<Void> sendByLecture(
 		@PathVariable Long lectureId,
 		@RequestBody NotificationSendRequest request) {
-		notificationFacade.sendNotificationByLectureIdWithRequest(lectureId, request);
+		notificationFacade.sendNotificationByLectureId(lectureId, request);
 		return ResponseEntity.noContent().build();
 	}
 
@@ -56,7 +56,7 @@ public class NotificationControllerImpl implements NotificationController {
 	public ResponseEntity<Void> sendByUserId(
 		@PathVariable Long userId,
 		@RequestBody NotificationSendRequest request) {
-		notificationFacade.sendNotificationWithRequest(userId, request);
+		notificationFacade.sendNotificationByReceiverId(userId, request);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/presentation/request/NotificationSendRequest.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/notification/presentation/request/NotificationSendRequest.java
@@ -2,10 +2,12 @@ package goorm.saerojinro.api.notification.presentation.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import org.hibernate.validator.constraints.Length;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+@Builder
 public record NotificationSendRequest(
 	@Schema(description = "제목", example = "\"개발 그렇게 하는거 아닌데\" 강의 취소 관련", requiredMode = REQUIRED)
 	@Length(min = 1, max = 100)

--- a/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
+++ b/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
@@ -1,0 +1,36 @@
+package notification.application;
+
+import goorm.saerojinro.api.notification.application.NotificationFacade;
+import goorm.saerojinro.domain.notification.application.NotificationCommandService;
+import goorm.saerojinro.domain.notification.application.NotificationQueryService;
+import goorm.saerojinro.domain.notification.domain.EmitterRepository;
+import goorm.saerojinro.domain.notification.domain.NotificationRepository;
+import goorm.saerojinro.domain.user.application.UserQueryService;
+import goorm.saerojinro.domain.user.domain.UserRepository;
+import mock.repository.FakeNotificationRepository;
+import mock.repository.FakeUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class NotificationFacadeTest {
+	private NotificationFacade notificationFacade;
+
+	@Mock
+	private EmitterRepository emitterRepository;
+
+	@BeforeEach
+	public void init() {
+		NotificationRepository repository = new FakeNotificationRepository();
+		NotificationQueryService queryService = new NotificationQueryService(repository);
+		NotificationCommandService commandService = new NotificationCommandService(repository);
+
+		UserRepository userRepository = new FakeUserRepository();
+		UserQueryService userQueryService = new UserQueryService(userRepository, new BCryptPasswordEncoder());
+
+		notificationFacade = new NotificationFacade(commandService, queryService, emitterRepository, userQueryService);
+
+	}
+
+
+}

--- a/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
+++ b/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
@@ -1,36 +1,128 @@
 package notification.application;
 
 import goorm.saerojinro.api.notification.application.NotificationFacade;
+import goorm.saerojinro.api.notification.presentation.request.NotificationSendRequest;
 import goorm.saerojinro.domain.notification.application.NotificationCommandService;
 import goorm.saerojinro.domain.notification.application.NotificationQueryService;
 import goorm.saerojinro.domain.notification.domain.EmitterRepository;
 import goorm.saerojinro.domain.notification.domain.NotificationRepository;
 import goorm.saerojinro.domain.user.application.UserQueryService;
+import goorm.saerojinro.domain.user.domain.User;
 import goorm.saerojinro.domain.user.domain.UserRepository;
+import goorm.saerojinro.infra.repository.impl.EmitterRepositoryImpl;
 import mock.repository.FakeNotificationRepository;
 import mock.repository.FakeUserRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.Mock;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static goorm.saerojinro.common.domain.BaseRole.ADMIN;
 
 public class NotificationFacadeTest {
 	private NotificationFacade notificationFacade;
-
-	@Mock
-	private EmitterRepository emitterRepository;
 
 	@BeforeEach
 	public void init() {
 		NotificationRepository repository = new FakeNotificationRepository();
 		NotificationQueryService queryService = new NotificationQueryService(repository);
 		NotificationCommandService commandService = new NotificationCommandService(repository);
+		EmitterRepository emitterRepository = new EmitterRepositoryImpl();
 
+		BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 		UserRepository userRepository = new FakeUserRepository();
-		UserQueryService userQueryService = new UserQueryService(userRepository, new BCryptPasswordEncoder());
+		UserQueryService userQueryService = new UserQueryService(userRepository, passwordEncoder);
 
 		notificationFacade = new NotificationFacade(commandService, queryService, emitterRepository, userQueryService);
 
+		userRepository.save(User.builder()
+			.email("email@email.com")
+			.password(passwordEncoder.encode("password1234!"))
+			.name("박민준")
+			.role(ADMIN)
+			.build()
+		);
+
+		UserDetails user = userQueryService.getByEmail("email@email.com");
+		SecurityContext context = SecurityContextHolder.getContext();
+		context.setAuthentication(
+			new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities())
+		);
 	}
 
+	@Test
+	@DisplayName("subscribe")
+	void subscribe_Success() {
+		// when
+		SseEmitter emitter = notificationFacade.subscribe();
+
+		// then
+		Assertions.assertNotNull(emitter);
+	}
+
+	// TODO LectureService 이후
+	//	@Test
+	@DisplayName("sendNotificationByLectureIdWithRequest")
+	void sendNotificationByLectureIdWithRequest_Success() {
+		// given
+		NotificationSendRequest request = NotificationSendRequest.builder()
+			.title("title")
+			.contents("contents")
+			.build();
+
+		// when
+//		notificationFacade.sendNotificationByLectureIdWithRequest();
+
+		// then
+
+	}
+
+	@Test
+	@DisplayName("sendNotificationWithRequest")
+	void sendNotificationWithRequest_Success() {
+		// when
+		notificationFacade.subscribe();
+
+		// then
+
+	}
+
+
+	@Test
+	@DisplayName("sendNotification")
+	void sendNotification_Success() {
+		// when
+		notificationFacade.subscribe();
+
+		// then
+
+	}
+
+
+	@Test
+	@DisplayName("sendNotificationAll")
+	void sendNotificationAll_Success() {
+		// when
+		notificationFacade.subscribe();
+
+		// then
+
+	}
+
+	@Test
+	@DisplayName("ReceivedNotificationListResponse")
+	void ReceivedNotificationListResponse_Success() {
+		// when
+		notificationFacade.subscribe();
+
+		// then
+
+	}
 
 }

--- a/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
+++ b/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
@@ -68,7 +68,7 @@ public class NotificationFacadeTest {
 	}
 
 	@Test
-	@DisplayName("subscribe")
+	@DisplayName("subscribe는 SseEmitter를 생성한다")
 	void subscribe_Success() {
 		// when
 		SseEmitter emitter = notificationFacade.subscribe();
@@ -79,8 +79,8 @@ public class NotificationFacadeTest {
 
 	// TODO ReservationService 이후
 	//	@Test
-	@DisplayName("sendNotificationByLectureIdWithRequest")
-	void sendNotificationByLectureIdWithRequest_Success() {
+	@DisplayName("sendNotificationByLectureId은 Lecture를 예약한 참가자에게 알림을 전송한다")
+	void sendNotificationByLectureId_Success() {
 		// given
 		NotificationSendRequest request = NotificationSendRequest.builder()
 			.title(TITLE)
@@ -88,15 +88,15 @@ public class NotificationFacadeTest {
 			.build();
 
 		// when
-//		notificationFacade.sendNotificationByLectureIdWithRequest();
+//		notificationFacade.sendNotificationByLectureId();
 
 		// then
 
 	}
 
 	@Test
-	@DisplayName("sendNotificationWithRequest")
-	void sendNotificationWithRequest_Success() {
+	@DisplayName("sendNotificationByReceiverId는 특정 참가자에게 알림을 전송한다")
+	void sendNotificationByReceiverId_Success() {
 		// given
 		notificationFacade.subscribe();
 		Long receiverId = 1L;
@@ -106,7 +106,7 @@ public class NotificationFacadeTest {
 			.build();
 
 		// when
-		notificationFacade.sendNotificationWithRequest(receiverId, request);
+		notificationFacade.sendNotificationByReceiverId(receiverId, request);
 
 		// then
 		List<Notification> notifications = repository.findByUserId(receiverId);
@@ -117,7 +117,7 @@ public class NotificationFacadeTest {
 	}
 
 	@Test
-	@DisplayName("sendNotification")
+	@DisplayName("sendNotification는 알림을 전송한다")
 	void sendNotification_Success() {
 		// given
 		notificationFacade.subscribe();
@@ -139,7 +139,7 @@ public class NotificationFacadeTest {
 
 
 	@Test
-	@DisplayName("sendNotificationAll")
+	@DisplayName("sendNotificationAll는 모든 참가자에게 알림을 전송한다")
 	void sendNotificationAll_Success() {
 		// given
 		notificationFacade.subscribe();
@@ -160,7 +160,7 @@ public class NotificationFacadeTest {
 	}
 
 	@Test
-	@DisplayName("myNotification")
+	@DisplayName("myNotification은 현재 로그인한 유저가 받은 알림을 조회한다")
 	void myNotification_Success() {
 		// given
 		notificationFacade.subscribe();

--- a/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
+++ b/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
@@ -2,9 +2,11 @@ package notification.application;
 
 import goorm.saerojinro.api.notification.application.NotificationFacade;
 import goorm.saerojinro.api.notification.presentation.request.NotificationSendRequest;
+import goorm.saerojinro.api.notification.presentation.response.ReceivedNotificationListResponse;
 import goorm.saerojinro.domain.notification.application.NotificationCommandService;
 import goorm.saerojinro.domain.notification.application.NotificationQueryService;
 import goorm.saerojinro.domain.notification.domain.EmitterRepository;
+import goorm.saerojinro.domain.notification.domain.Notification;
 import goorm.saerojinro.domain.notification.domain.NotificationRepository;
 import goorm.saerojinro.domain.user.application.UserQueryService;
 import goorm.saerojinro.domain.user.domain.User;
@@ -23,20 +25,29 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
+
 import static goorm.saerojinro.common.domain.BaseRole.ADMIN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class NotificationFacadeTest {
 	private NotificationFacade notificationFacade;
+	private NotificationRepository repository;
+	private UserRepository userRepository;
+
+	private final String TITLE = "title";
+	private final String CONTENTS = "contents";
 
 	@BeforeEach
 	public void init() {
-		NotificationRepository repository = new FakeNotificationRepository();
+		repository = new FakeNotificationRepository();
 		NotificationQueryService queryService = new NotificationQueryService(repository);
 		NotificationCommandService commandService = new NotificationCommandService(repository);
 		EmitterRepository emitterRepository = new EmitterRepositoryImpl();
 
 		BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-		UserRepository userRepository = new FakeUserRepository();
+		userRepository = new FakeUserRepository();
 		UserQueryService userQueryService = new UserQueryService(userRepository, passwordEncoder);
 
 		notificationFacade = new NotificationFacade(commandService, queryService, emitterRepository, userQueryService);
@@ -63,17 +74,17 @@ public class NotificationFacadeTest {
 		SseEmitter emitter = notificationFacade.subscribe();
 
 		// then
-		Assertions.assertNotNull(emitter);
+		assertNotNull(emitter);
 	}
 
-	// TODO LectureService 이후
+	// TODO ReservationService 이후
 	//	@Test
 	@DisplayName("sendNotificationByLectureIdWithRequest")
 	void sendNotificationByLectureIdWithRequest_Success() {
 		// given
 		NotificationSendRequest request = NotificationSendRequest.builder()
-			.title("title")
-			.contents("contents")
+			.title(TITLE)
+			.contents(CONTENTS)
 			.build();
 
 		// when
@@ -86,43 +97,87 @@ public class NotificationFacadeTest {
 	@Test
 	@DisplayName("sendNotificationWithRequest")
 	void sendNotificationWithRequest_Success() {
-		// when
+		// given
 		notificationFacade.subscribe();
+		Long receiverId = 1L;
+		NotificationSendRequest request = NotificationSendRequest.builder()
+			.title(TITLE)
+			.contents(CONTENTS)
+			.build();
+
+		// when
+		notificationFacade.sendNotificationWithRequest(receiverId, request);
 
 		// then
-
+		List<Notification> notifications = repository.findByUserId(receiverId);
+		Notification result = notifications.get(0);
+		assertNotNull(notifications);
+		Assertions.assertEquals(TITLE, result.getTitle());
+		Assertions.assertEquals(CONTENTS, result.getContents());
 	}
-
 
 	@Test
 	@DisplayName("sendNotification")
 	void sendNotification_Success() {
-		// when
+		// given
 		notificationFacade.subscribe();
+		Long receiverId = 1L;
+		Notification notification = Notification.createNotification(
+			userRepository.findById(1L).get(), TITLE, CONTENTS
+		);
+
+		// when
+		notificationFacade.sendNotification(receiverId, notification);
 
 		// then
-
+		List<Notification> notifications = repository.findByUserId(receiverId);
+		Notification result = notifications.get(0);
+		assertNotNull(notifications);
+		Assertions.assertEquals(TITLE, result.getTitle());
+		Assertions.assertEquals(CONTENTS, result.getContents());
 	}
 
 
 	@Test
 	@DisplayName("sendNotificationAll")
 	void sendNotificationAll_Success() {
-		// when
+		// given
 		notificationFacade.subscribe();
+		NotificationSendRequest request = NotificationSendRequest.builder()
+			.title(TITLE)
+			.contents(CONTENTS)
+			.build();
+
+		// when
+		notificationFacade.sendNotificationAll(request);
 
 		// then
-
+		List<Notification> notifications = repository.findByUserIdIsNull();
+		Notification result = notifications.get(0);
+		assertNotNull(notifications);
+		Assertions.assertEquals(TITLE, result.getTitle());
+		Assertions.assertEquals(CONTENTS, result.getContents());
 	}
 
 	@Test
-	@DisplayName("ReceivedNotificationListResponse")
-	void ReceivedNotificationListResponse_Success() {
-		// when
+	@DisplayName("myNotification")
+	void myNotification_Success() {
+		// given
 		notificationFacade.subscribe();
+		Long receiverId = 1L;
+		Notification notification = Notification.createNotification(
+			userRepository.findById(1L).get(), TITLE, CONTENTS
+		);
+		notificationFacade.sendNotification(receiverId, notification);
+
+		// when
+		ReceivedNotificationListResponse response = notificationFacade.myNotification();
 
 		// then
-
+		assertNotNull(response);
+		assertEquals(1, response.contents().size());
+		assertEquals(TITLE, response.contents().get(0).title());
+		assertEquals(CONTENTS, response.contents().get(0).contents());
 	}
 
 }

--- a/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
+++ b/saerojinro-api/src/testFixtures/java/notification/application/NotificationFacadeTest.java
@@ -3,16 +3,21 @@ package notification.application;
 import goorm.saerojinro.api.notification.application.NotificationFacade;
 import goorm.saerojinro.api.notification.presentation.request.NotificationSendRequest;
 import goorm.saerojinro.api.notification.presentation.response.ReceivedNotificationListResponse;
+import goorm.saerojinro.domain.lecture.domain.Lecture;
 import goorm.saerojinro.domain.notification.application.NotificationCommandService;
 import goorm.saerojinro.domain.notification.application.NotificationQueryService;
 import goorm.saerojinro.domain.notification.domain.EmitterRepository;
 import goorm.saerojinro.domain.notification.domain.Notification;
 import goorm.saerojinro.domain.notification.domain.NotificationRepository;
+import goorm.saerojinro.domain.reservation.application.ReservationQueryService;
+import goorm.saerojinro.domain.reservation.domain.Reservation;
+import goorm.saerojinro.domain.reservation.domain.ReservationRepository;
 import goorm.saerojinro.domain.user.application.UserQueryService;
 import goorm.saerojinro.domain.user.domain.User;
 import goorm.saerojinro.domain.user.domain.UserRepository;
 import goorm.saerojinro.infra.repository.impl.EmitterRepositoryImpl;
 import mock.repository.FakeNotificationRepository;
+import mock.repository.FakeReservationRepository;
 import mock.repository.FakeUserRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +40,9 @@ public class NotificationFacadeTest {
 	private NotificationFacade notificationFacade;
 	private NotificationRepository repository;
 	private UserRepository userRepository;
+	private ReservationRepository reservationRepository;
+
+	private User user;
 
 	private final String TITLE = "title";
 	private final String CONTENTS = "contents";
@@ -50,9 +58,13 @@ public class NotificationFacadeTest {
 		userRepository = new FakeUserRepository();
 		UserQueryService userQueryService = new UserQueryService(userRepository, passwordEncoder);
 
-		notificationFacade = new NotificationFacade(commandService, queryService, emitterRepository, userQueryService);
+		reservationRepository = new FakeReservationRepository();
+		ReservationQueryService reservationQueryService = new ReservationQueryService(reservationRepository);
 
-		userRepository.save(User.builder()
+		notificationFacade = new NotificationFacade(
+			commandService, queryService, emitterRepository, userQueryService, reservationQueryService);
+
+		user = userRepository.save(User.builder()
 			.email("email@email.com")
 			.password(passwordEncoder.encode("password1234!"))
 			.name("박민준")
@@ -77,21 +89,28 @@ public class NotificationFacadeTest {
 		assertNotNull(emitter);
 	}
 
-	// TODO ReservationService 이후
-	//	@Test
+	@Test
 	@DisplayName("sendNotificationByLectureId은 Lecture를 예약한 참가자에게 알림을 전송한다")
 	void sendNotificationByLectureId_Success() {
 		// given
+		notificationFacade.subscribe();
+		Lecture lecture = Lecture.builder().id(1L).build();
+		reservationRepository.save(Reservation.createReservation(user, lecture));
+
 		NotificationSendRequest request = NotificationSendRequest.builder()
 			.title(TITLE)
 			.contents(CONTENTS)
 			.build();
 
 		// when
-//		notificationFacade.sendNotificationByLectureId();
+		notificationFacade.sendNotificationByLectureId(1L, request);
 
 		// then
-
+		List<Notification> notifications = repository.findByUserId(user.getId());
+		Notification result = notifications.get(0);
+		assertNotNull(notifications);
+		Assertions.assertEquals(TITLE, result.getTitle());
+		Assertions.assertEquals(CONTENTS, result.getContents());
 	}
 
 	@Test

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/notification/domain/EmitterRepository.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/notification/domain/EmitterRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 
 public interface EmitterRepository {
-	SseEmitter save(Long id, SseEmitter emitter);
+	SseEmitter save(Long id);
 
 	Optional<SseEmitter> findById(Long id);
 

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/notification/domain/NotificationRepository.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/notification/domain/NotificationRepository.java
@@ -5,7 +5,7 @@ import java.util.List;
 public interface NotificationRepository {
 	Notification save(Notification notification);
 
-	List<Notification> findByUserId(Long lectureId);
+	List<Notification> findByUserId(Long userId);
 
 	List<Notification> findByUserIdIsNull();
 }

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/reservation/application/ReservationQueryService.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/reservation/application/ReservationQueryService.java
@@ -5,17 +5,16 @@ import goorm.saerojinro.domain.reservation.domain.Reservation;
 import goorm.saerojinro.domain.reservation.domain.ReservationRepository;
 import goorm.saerojinro.domain.reservation.exception.ReservationNotFoundException;
 import goorm.saerojinro.domain.user.domain.User;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Getter
+@Service
 @RequiredArgsConstructor
 public class ReservationQueryService {
-    
     private final ReservationRepository reservationRepository;
-    
+
     public List<Reservation> getAllReservationByUser(User user){
         return reservationRepository.findByUser(user);
     }
@@ -29,5 +28,7 @@ public class ReservationQueryService {
         return reservationRepository.existByUserAndLecture(user, lecture);
     }
 
-    
+    public List<Reservation> getAllByLectureId(Long lectureId) {
+        return reservationRepository.findAllByLectureId(lectureId);
+    }
 }

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/reservation/domain/ReservationRepository.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/reservation/domain/ReservationRepository.java
@@ -17,4 +17,6 @@ public interface ReservationRepository {
     Reservation save(Reservation reservation);
 
     void delete(Reservation reservation);
+
+	List<Reservation> findAllByLectureId(Long lectureId);
 }

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/application/UserQueryService.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/application/UserQueryService.java
@@ -1,5 +1,8 @@
 package goorm.saerojinro.domain.user.application;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +17,12 @@ import lombok.RequiredArgsConstructor;
 public class UserQueryService {
 	private final UserRepository userRepository;
 	private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+	public User me() {
+		SecurityContext context = SecurityContextHolder.getContext();
+		Authentication authentication = context.getAuthentication();
+		return (User) authentication.getPrincipal();
+	}
 
 	public User getByEmail(String email) {
 		return userRepository.findByEmail(email)

--- a/saerojinro-domain/src/testFixtures/java/mock/repository/FakeNotificationRepository.java
+++ b/saerojinro-domain/src/testFixtures/java/mock/repository/FakeNotificationRepository.java
@@ -26,9 +26,9 @@ public class FakeNotificationRepository implements NotificationRepository {
 	}
 
 	@Override
-	public List<Notification> findByUserId(Long lectureId) {
+	public List<Notification> findByUserId(Long userId) {
 		return data.stream()
-			.filter(n -> n.getUser().getId().equals(lectureId))
+			.filter(n -> n.getUser().getId().equals(userId))
 			.toList();
 	}
 

--- a/saerojinro-domain/src/testFixtures/java/mock/repository/FakeReservationRepository.java
+++ b/saerojinro-domain/src/testFixtures/java/mock/repository/FakeReservationRepository.java
@@ -53,4 +53,10 @@ public class FakeReservationRepository implements ReservationRepository {
                 .findFirst();
     }
 
+    @Override
+    public List<Reservation> findAllByLectureId(Long lectureId) {
+        return data.stream()
+            .filter(r -> r.getLecture().getId().equals(lectureId))
+            .toList();
+    }
 }

--- a/saerojinro-domain/src/testFixtures/java/notification/NotificationDomainTest.java
+++ b/saerojinro-domain/src/testFixtures/java/notification/NotificationDomainTest.java
@@ -25,6 +25,7 @@ public class NotificationDomainTest {
 	@Test
 	@DisplayName("Notification을 성공적으로 생성한다")
 	void createNotification_Success() {
+		// then
 		assertNotNull(notification, "Notification 객체가 null이면 안 됩니다.");
 		assertEquals(TITLE, notification.getTitle());
 		assertEquals(CONTENTS, notification.getContents());

--- a/saerojinro-domain/src/testFixtures/java/notification/application/NotificationCommandServiceTest.java
+++ b/saerojinro-domain/src/testFixtures/java/notification/application/NotificationCommandServiceTest.java
@@ -30,7 +30,10 @@ public class NotificationCommandServiceTest {
 	@Test
 	@DisplayName("save는 notification을 저장한다")
 	public void save_Success() {
+		// when
 		Long saved = notificationCommandService.save(notification);
+
+		// then
 		assertEquals(1L, saved);
 	}
 }

--- a/saerojinro-domain/src/testFixtures/java/notification/application/NotificationQueryServiceTest.java
+++ b/saerojinro-domain/src/testFixtures/java/notification/application/NotificationQueryServiceTest.java
@@ -35,8 +35,10 @@ public class NotificationQueryServiceTest {
 	@Test
 	@DisplayName("findByUserId는 notification을 조회한다")
 	public void findByUserId_Success() {
+		// when
 		Notification notification = notificationQueryService.findByUserId(USER_ID).get(0);
 
+		// then
 		assertEquals(1L, notification.getId());
 		assertEquals(TITLE, notification.getTitle());
 		assertEquals(CONTENTS, notification.getContents());
@@ -45,7 +47,10 @@ public class NotificationQueryServiceTest {
 	@Test
 	@DisplayName("findByUserId는 userId가 존재하지 않을 때 빈 리스트를 반환한다")
 	public void findByUserId_return_Empty() {
+		// when
 		List<Notification> notifications = notificationQueryService.findByUserId(100L);
+
+		// then
 		assertEquals(0, notifications.size());
 	}
 }

--- a/saerojinro-domain/src/testFixtures/java/reservation/application/ReservationQueryServiceTest.java
+++ b/saerojinro-domain/src/testFixtures/java/reservation/application/ReservationQueryServiceTest.java
@@ -138,4 +138,18 @@ public class ReservationQueryServiceTest {
         assertThat(isExist).isTrue();
     }
 
+    @Test
+    @DisplayName("getAllByLectureId 는 Lecture 에 예약한 예약 정보를 반환할 수 있다.")
+    public void getAllByLectureId_Success(){
+        // given
+
+        // when
+        List<Reservation> reservationList = reservationQueryService.getAllByLectureId(LECTURE_ID);
+
+        // then
+        assertEquals(1, reservationList.size());
+        assertEquals(1L, reservationList.get(0).getLecture().getId());
+        assertEquals(LECTURE_TITLE, reservationList.get(0).getLecture().getTitle());
+        assertEquals(LECTURE_CONTENTS, reservationList.get(0).getLecture().getContents());
+    }
 }

--- a/saerojinro-domain/src/testFixtures/java/user/application/UserQueryServiceTest.java
+++ b/saerojinro-domain/src/testFixtures/java/user/application/UserQueryServiceTest.java
@@ -44,6 +44,18 @@ public class UserQueryServiceTest {
 	}
 
 	@Test
+	@DisplayName("me는 유저를 현재 로그인한 유저를 조회할 수 있다")
+	public void me_Success() {
+		// given
+		// when
+		User result = userQueryService.me();
+
+		// then
+		assertEquals("박민준", result.getName());
+		assertEquals(ADMIN, result.getRole());
+	}
+
+	@Test
 	@DisplayName("getByEmail은 유저를 이메일로 조회할 수 있다")
 	public void getByEmail_Success() {
 		// given

--- a/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/impl/EmitterRepositoryImpl.java
+++ b/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/impl/EmitterRepositoryImpl.java
@@ -15,7 +15,8 @@ public class EmitterRepositoryImpl implements EmitterRepository {
 	private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
 	@Override
-	public SseEmitter save(Long id, SseEmitter emitter) {
+	public SseEmitter save(Long id) {
+		SseEmitter emitter = new SseEmitter(12 * 60 * 60 * 1000L);
 		emitter.onCompletion(() -> emitters.remove(id));
 		emitter.onTimeout(emitter::complete);
 		emitters.put(id, emitter);

--- a/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/impl/ReservationRepositoryImpl.java
+++ b/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/impl/ReservationRepositoryImpl.java
@@ -40,4 +40,9 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     public void delete(Reservation reservation) {
         reservationJpaRepository.delete(reservation);
     }
+
+    @Override
+    public List<Reservation> findAllByLectureId(Long lectureId) {
+        return reservationJpaRepository.findAllByLectureId(lectureId);
+    }
 }

--- a/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/jpa/ReservationJpaRepository.java
+++ b/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/jpa/ReservationJpaRepository.java
@@ -16,4 +16,6 @@ public interface ReservationJpaRepository extends JpaRepository<Reservation, Lon
     Optional<Reservation> findByUserAndLecture(User user, Lecture lecture);
 
     void delete(Reservation reservation);
+
+	List<Reservation> findAllByLectureId(Long lectureId);
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
> - #28 

## 📍주요 변경 사항
> 이전 커밋에서 TODO로 남겨놓은 부분을 완성했습니다.
- 현재 로그인한 유저의 정보를 가져오는 메소드 작성
- LectureId를 이용해 Notification 리스트를 가져오는 메소드 작성

> 테스트 코드를 작성하고 일부 오타를 수정했습니다.

## 🗣To Reviewer
> 의논이나 고려해야하는 내용을 작성해 주세요.