### PR TITLE
feature/#37 유저 삭제 기능 구현

### DIFF
--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/user/application/UserFacade.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/user/application/UserFacade.java
@@ -24,6 +24,6 @@ public class UserFacade {
 	@Transactional
 	public void delete() {
 		User user = userQueryService.me();
-		user.delete();
+		userCommandService.delete(user);
 	}
 }

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/user/application/UserFacade.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/user/application/UserFacade.java
@@ -20,4 +20,10 @@ public class UserFacade {
 		User user = userQueryService.me();
 		userCommandService.update(user, request.name(), request.email(), request.interest());
 	}
+
+	@Transactional
+	public void delete() {
+		User user = userQueryService.me();
+		userCommandService.delete(user);
+	}
 }

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/user/application/UserFacade.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/user/application/UserFacade.java
@@ -24,6 +24,6 @@ public class UserFacade {
 	@Transactional
 	public void delete() {
 		User user = userQueryService.me();
-		userCommandService.delete(user);
+		user.delete();
 	}
 }

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/user/presentation/UserController.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/user/presentation/UserController.java
@@ -21,10 +21,17 @@ public interface UserController {
 	@ApiResponse(
 		responseCode = "204",
 		content = @Content(schema = @Schema(implementation = UserUpdateRequest.class)))
-	ResponseEntity<Void> updateUser(
+	ResponseEntity<Void> update(
 		@Parameter(
 			description = "회원 정보 수정 request 객체 입니다.",
 			required = true
 		) @Valid @RequestBody UserUpdateRequest request
 	);
+
+	@Operation(summary = "회원 탈퇴 API", description = """
+			- Description : 이 API는 회원정보를 삭제합니다.
+			- Assignee : 박민준
+		""")
+	@ApiResponse(responseCode = "204")
+	ResponseEntity<Void> delete();
 }

--- a/saerojinro-api/src/main/java/goorm/saerojinro/api/user/presentation/UserControllerImpl.java
+++ b/saerojinro-api/src/main/java/goorm/saerojinro/api/user/presentation/UserControllerImpl.java
@@ -1,6 +1,7 @@
 package goorm.saerojinro.api.user.presentation;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,8 +18,15 @@ public class UserControllerImpl implements UserController{
 
 	@Override
 	@PatchMapping
-	public ResponseEntity<Void> updateUser(UserUpdateRequest request) {
+	public ResponseEntity<Void> update(UserUpdateRequest request) {
 		userFacade.update(request);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Override
+	@DeleteMapping
+	public ResponseEntity<Void> delete() {
+		userFacade.delete();
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/saerojinro-api/src/testFixtures/java/user/UserFacadeTest.java
+++ b/saerojinro-api/src/testFixtures/java/user/UserFacadeTest.java
@@ -3,6 +3,7 @@ package user;
 import static goorm.saerojinro.common.domain.BaseRole.ADMIN;
 import static goorm.saerojinro.common.domain.Category.BACKEND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -72,6 +73,7 @@ public class UserFacadeTest {
 		// when
 		userFacade.delete();
 
-		// then todo : 유저 정보 조회 후 구현하겠습니다
+		// then
+		assertNotNull(user.getDeletedAt());
 	}
 }

--- a/saerojinro-api/src/testFixtures/java/user/UserFacadeTest.java
+++ b/saerojinro-api/src/testFixtures/java/user/UserFacadeTest.java
@@ -48,8 +48,8 @@ public class UserFacadeTest {
 	}
 
 	@Test
-	@DisplayName("updateUser는 유저의 정보를 수정한다")
-	public void updateUser_Success() {
+	@DisplayName("update는 유저의 정보를 수정한다")
+	public void update_Success() {
 		// given
 		UserUpdateRequest request = UserUpdateRequest.builder()
 			.email("update@email.com")
@@ -64,5 +64,14 @@ public class UserFacadeTest {
 		assertEquals("update@email.com", user.getEmail());
 		assertEquals("박준", user.getName());
 		assertEquals(BACKEND, user.getInterest());
+	}
+
+	@Test
+	@DisplayName("delete는 현재 로그인 된 유저 정보를 삭제한다.")
+	public void delete_Success() {
+		// when
+		userFacade.delete();
+
+		// then todo : 유저 정보 조회 후 구현하겠습니다
 	}
 }

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/application/UserCommandService.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/application/UserCommandService.java
@@ -43,6 +43,6 @@ public class UserCommandService {
 	}
 
 	public void delete(User user) {
-		userRepository.delete(user);
+		user.delete();
 	}
 }

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/application/UserCommandService.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/application/UserCommandService.java
@@ -41,4 +41,8 @@ public class UserCommandService {
 		user.updateEmail(email);
 		user.updateInterest(category);
 	}
+
+	public void delete(User user) {
+		userRepository.delete(user);
+	}
 }

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/domain/User.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/domain/User.java
@@ -2,7 +2,6 @@ package goorm.saerojinro.domain.user.domain;
 
 import static goorm.saerojinro.common.domain.BaseRole.ADMIN;
 import static goorm.saerojinro.common.domain.BaseRole.ATTENDEE;
-import static goorm.saerojinro.common.domain.Provider.GOOGLE;
 import static goorm.saerojinro.common.domain.Provider.KAKAO;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/domain/UserRepository.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/user/domain/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository {
 	Optional<User> findByOauthIdentityAndProvider(String identifier, Provider provider);
 
 	Optional<User> findById(Long id);
+
+	void delete(User user);
 }

--- a/saerojinro-domain/src/testFixtures/java/mock/repository/FakeUserRepository.java
+++ b/saerojinro-domain/src/testFixtures/java/mock/repository/FakeUserRepository.java
@@ -54,7 +54,12 @@ public class FakeUserRepository implements UserRepository {
 			return data.stream().filter(u -> u.getId() == userId).findAny();
 		}
 	}
-  
+
+	@Override
+	public void delete(User user) {
+		data.remove(user);
+	}
+
 	private boolean isValidSocialUser(User user) {
 		return user.getOauthIdentity() != null && user.getProvider() != null;
 	}

--- a/saerojinro-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
+++ b/saerojinro-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
@@ -3,6 +3,7 @@ package user.application;
 import static goorm.saerojinro.common.domain.Category.BACKEND;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,12 +19,11 @@ import mock.repository.FakeUserRepository;
 public class UserCommandServiceTest {
 	private UserCommandService userCommandService;
 	private BCryptPasswordEncoder bCryptPasswordEncoder;
-	private FakeUserRepository fakeUserRepository;
 	private User user;
 
 	@BeforeEach
 	public void init() {
-		fakeUserRepository = new FakeUserRepository();
+		FakeUserRepository fakeUserRepository = new FakeUserRepository();
 		bCryptPasswordEncoder = new BCryptPasswordEncoder();
 		userCommandService = new UserCommandService(
 			fakeUserRepository
@@ -124,6 +124,6 @@ public class UserCommandServiceTest {
 		userCommandService.delete(user);
 
 		// then
-		assertThat(fakeUserRepository.findByEmail(email)).isEmpty();
+		assertNotNull(user.getDeletedAt());
 	}
 }

--- a/saerojinro-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
+++ b/saerojinro-domain/src/testFixtures/java/user/application/UserCommandServiceTest.java
@@ -1,6 +1,7 @@
 package user.application;
 
 import static goorm.saerojinro.common.domain.Category.BACKEND;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,11 +18,12 @@ import mock.repository.FakeUserRepository;
 public class UserCommandServiceTest {
 	private UserCommandService userCommandService;
 	private BCryptPasswordEncoder bCryptPasswordEncoder;
+	private FakeUserRepository fakeUserRepository;
 	private User user;
 
 	@BeforeEach
 	public void init() {
-		FakeUserRepository fakeUserRepository = new FakeUserRepository();
+		fakeUserRepository = new FakeUserRepository();
 		bCryptPasswordEncoder = new BCryptPasswordEncoder();
 		userCommandService = new UserCommandService(
 			fakeUserRepository
@@ -106,5 +108,22 @@ public class UserCommandServiceTest {
 		assertEquals(newName, user.getName());
 		assertEquals(newEmail, user.getEmail());
 		assertEquals(newInterest, user.getInterest());
+	}
+
+	@Test
+	@DisplayName("delete는 해당 User를 삭제한다")
+	public void delete_Success() {
+		// given
+		String email = "admin@gmail.com";
+		String password = "password";
+		String name = "admin";
+
+		User user = userCommandService.createAdmin(email, password, name);
+
+		// when
+		userCommandService.delete(user);
+
+		// then
+		assertThat(fakeUserRepository.findByEmail(email)).isEmpty();
 	}
 }

--- a/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/impl/UserRepositoryImpl.java
+++ b/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/impl/UserRepositoryImpl.java
@@ -22,7 +22,7 @@ public class UserRepositoryImpl implements UserRepository {
 
 	@Override
 	public Optional<User> findByEmail(String email) {
-		return userJpaRepository.findByEmail(email);
+		return userJpaRepository.findByEmailAndDeletedAtIsNull(email);
 	}
 
 	@Override
@@ -32,7 +32,7 @@ public class UserRepositoryImpl implements UserRepository {
 
   	@Override
 	public Optional<User> findById(Long id) {
-		return userJpaRepository.findById(id);
+		return userJpaRepository.findByIdAndDeletedAtIsNull(id);
 	}
 
 	@Override

--- a/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/impl/UserRepositoryImpl.java
+++ b/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/impl/UserRepositoryImpl.java
@@ -34,4 +34,9 @@ public class UserRepositoryImpl implements UserRepository {
 	public Optional<User> findById(Long id) {
 		return userJpaRepository.findById(id);
 	}
+
+	@Override
+	public void delete(User user) {
+		userJpaRepository.delete(user);
+	}
 }

--- a/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/jpa/UserJpaRepository.java
+++ b/saerojinro-infra/src/main/java/goorm/saerojinro/infra/repository/jpa/UserJpaRepository.java
@@ -8,7 +8,9 @@ import goorm.saerojinro.common.domain.Provider;
 import goorm.saerojinro.domain.user.domain.User;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
-	Optional<User> findByEmail(String email);
+	Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
 	Optional<User> findByOauthIdentityAndProvider(String identifier, Provider provider);
+
+	Optional<User> findByIdAndDeletedAtIsNull(Long id);
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
> 관련 있는 이슈를 태그해주세요.
- close #37 

## 📍주요 변경 사항
> 유저 삭제 기능 구현

## 🗣To Reviewer
> 삭제 시 유저 데이터는 요청으로 userId나 email을 받는 방식은 보안적으로 취약할 수 있다고 생각되어 
현재 로그인된 유저 정보를 SecurityContextHolder에서 가져오는 방식으로 처리했습니다..
잘못된 요청이나 의도적인 공격으로 다른 유저 데이터가 삭제되는 위험을 방지하기 위해,
본인 인증이 완료된 유저 정보만 활용하도록 구현했습니다.