### PR TITLE
feature/#106 대시보드 시간별 데이터 예상 인원 수 추가

### DIFF
--- a/saerojinro-admin/src/main/java/goorm/saerojinro/admin/api/dashboard/presentation/response/DashboardResponse.java
+++ b/saerojinro-admin/src/main/java/goorm/saerojinro/admin/api/dashboard/presentation/response/DashboardResponse.java
@@ -2,6 +2,7 @@ package goorm.saerojinro.admin.api.dashboard.presentation.response;
 
 import goorm.saerojinro.domain.dashboard.domain.Dashboard;
 import goorm.saerojinro.domain.dashboard.dto.DashboardAggregation;
+import goorm.saerojinro.domain.dashboard.dto.TimeRankDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -38,7 +39,8 @@ public record DashboardResponse(
 		example = "[{"
 			+ "\"rank\": 1, "
 			+ "\"day\": \"클린코드란\", "
-			+ "\"startTime\": \"2025-03-01T10:00:00\"}]",
+			+ "\"startTime\": \"2025-03-01T10:00:00\", "
+			+ "\"expectation\": \"200\"}]",
 		requiredMode = REQUIRED)
 	List<TimeRankResponse> timeRank
 ) {
@@ -56,9 +58,9 @@ public record DashboardResponse(
 			.toList();
 	}
 
-	private static List<TimeRankResponse> buildTimeRankResponse(List<LocalDateTime> times) {
+	private static List<TimeRankResponse> buildTimeRankResponse(List<TimeRankDto> times) {
 		return times.stream()
-			.map(t -> TimeRankResponse.from(t, times.indexOf(t) + 1))
+			.map(t -> TimeRankResponse.from(t.startTime(), t.rank(), t.expectation()))
 			.toList();
 	}
 }

--- a/saerojinro-admin/src/main/java/goorm/saerojinro/admin/api/dashboard/presentation/response/DashboardResponse.java
+++ b/saerojinro-admin/src/main/java/goorm/saerojinro/admin/api/dashboard/presentation/response/DashboardResponse.java
@@ -6,7 +6,6 @@ import goorm.saerojinro.domain.dashboard.dto.TimeRankDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;

--- a/saerojinro-admin/src/main/java/goorm/saerojinro/admin/api/dashboard/presentation/response/TimeRankResponse.java
+++ b/saerojinro-admin/src/main/java/goorm/saerojinro/admin/api/dashboard/presentation/response/TimeRankResponse.java
@@ -18,15 +18,19 @@ public record TimeRankResponse(
 	String day,
 
 	@Schema(description = "시작시간", example = "2025-03-01T10:00:00", requiredMode = REQUIRED)
-	LocalDateTime startTime
+	LocalDateTime startTime,
+
+	@Schema(description = "예상 인원", example = "200", requiredMode = REQUIRED)
+	int expectation
 ) {
-	public static TimeRankResponse from(LocalDateTime startTime, int rank) {
+	public static TimeRankResponse from(LocalDateTime startTime, int rank, int expectation) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M월 d일 E요일", Locale.KOREAN);
 
 		return TimeRankResponse.builder()
 			.rank(rank)
 			.day(startTime.format(formatter))
 			.startTime(startTime)
+			.expectation(expectation)
 			.build();
 	}
 }

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/dashboard/application/DashboardService.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/dashboard/application/DashboardService.java
@@ -3,6 +3,7 @@ package goorm.saerojinro.domain.dashboard.application;
 import goorm.saerojinro.domain.dashboard.domain.Dashboard;
 import goorm.saerojinro.domain.dashboard.domain.DashboardRepository;
 import goorm.saerojinro.domain.dashboard.dto.DashboardAggregation;
+import goorm.saerojinro.domain.dashboard.dto.TimeRankDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,17 +34,19 @@ public class DashboardService {
 			.toList();
 
 		// 시간 상위 10개
-		List<LocalDateTime> times = dashboardList.stream()
+		AtomicInteger rankCounter = new AtomicInteger(1);
+		List<TimeRankDto> timeRankDtos = dashboardList.stream()
 			.collect(
 				Collectors.groupingBy(Dashboard::getStartTime, Collectors.summingInt(Dashboard::getSum))
 			).entrySet().stream()
 			.sorted(Map.Entry.<LocalDateTime, Integer>comparingByValue().reversed())
 			.limit(10)
-			.map(Map.Entry::getKey)
-			.toList();
+			.map(entry ->
+				TimeRankDto.of(rankCounter.getAndIncrement(), entry.getKey(), entry.getValue())
+			).toList();
 
 		// 데이터 집계
-		return new DashboardAggregation(high, low, times);
+		return DashboardAggregation.of(high, low, timeRankDtos);
 	}
 
 	public Dashboard save(Dashboard dashboard) {

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/dashboard/dto/DashboardAggregation.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/dashboard/dto/DashboardAggregation.java
@@ -3,17 +3,16 @@ package goorm.saerojinro.domain.dashboard.dto;
 import goorm.saerojinro.domain.dashboard.domain.Dashboard;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
 public record DashboardAggregation(
 	List<Dashboard> top10Dashboards,
 	List<Dashboard> bottom10Dashboards,
-	List<LocalDateTime> top10Times
+	List<TimeRankDto> top10Times
 ) {
 	public static DashboardAggregation of(
-		List<Dashboard> top10Dashboards, List<Dashboard> bottom10Dashboards, List<LocalDateTime> top10Times) {
+		List<Dashboard> top10Dashboards, List<Dashboard> bottom10Dashboards, List<TimeRankDto> top10Times) {
 		return DashboardAggregation.builder()
 			.top10Dashboards(top10Dashboards)
 			.bottom10Dashboards(bottom10Dashboards)

--- a/saerojinro-domain/src/main/java/goorm/saerojinro/domain/dashboard/dto/TimeRankDto.java
+++ b/saerojinro-domain/src/main/java/goorm/saerojinro/domain/dashboard/dto/TimeRankDto.java
@@ -1,0 +1,20 @@
+package goorm.saerojinro.domain.dashboard.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record TimeRankDto(
+	int rank,
+	LocalDateTime startTime,
+	int expectation
+) {
+	public static TimeRankDto of(int rank, LocalDateTime startTime, int expectation) {
+		return TimeRankDto.builder()
+			.rank(rank)
+			.startTime(startTime)
+			.expectation(expectation)
+			.build();
+	}
+}

--- a/saerojinro-domain/src/testFixtures/java/dashboard/application/DashboardServiceTest.java
+++ b/saerojinro-domain/src/testFixtures/java/dashboard/application/DashboardServiceTest.java
@@ -50,7 +50,7 @@ public class DashboardServiceTest {
 		assertEquals(2L, all.top10Dashboards().get(1).getId());
 		assertEquals(2L, all.bottom10Dashboards().get(0).getId());
 		assertEquals(1L, all.bottom10Dashboards().get(1).getId());
-		assertEquals(START_TIME, all.top10Times().get(0));
+		assertEquals(START_TIME, all.top10Times().get(0).startTime());
 	}
 
 	@Test


### PR DESCRIPTION
## ⚡️ 관련 이슈
> 관련 있는 이슈를 태그해주세요.
- #106 

## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.
- 대시보드 시간별 데이터 예상 인원 수 추가 (예약 수 + 즐겨찾기 수)
  - timeRank#expectation

## 🌁 Screenshot
> 작업한 내용에 대한 스크린샷을 첨부해주세요.
<img width="316" alt="스크린샷 2025-03-13 오후 5 11 41" src="https://github.com/user-attachments/assets/d78de85f-e996-4e4b-9ea1-947e8d7b1255" />
