### PR TITLE
fix/#174 AuthController 권한 변경

### DIFF
--- a/saerojinro-auth/src/main/java/goorm/saerojinro/auth/api/presentation/AuthControllerImpl.java
+++ b/saerojinro-auth/src/main/java/goorm/saerojinro/auth/api/presentation/AuthControllerImpl.java
@@ -36,7 +36,6 @@ public class AuthControllerImpl implements AuthController {
 
 	@Override
 	@PostMapping("/reissue")
-	@PreAuthorize("hasRole('USER')")
 	public ResponseEntity<JwtResponse> reissue(ReissueRequest request) {
 		JwtResponse response = authFacade.reissue(request);
 		return ResponseEntity.ok(response);
@@ -44,7 +43,7 @@ public class AuthControllerImpl implements AuthController {
 
 	@Override
 	@PostMapping("/logout")
-	@PreAuthorize("hasRole('USER')")
+	@PreAuthorize("hasRole('ATTENDEE')")
 	public ResponseEntity<Void> logout(HttpServletRequest request) {
 		authFacade.logout(request);
 		return ResponseEntity.noContent().build();

--- a/saerojinro-common/src/main/java/goorm/saerojinro/common/exception/GlobalExceptionHandler.java
+++ b/saerojinro-common/src/main/java/goorm/saerojinro/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,13 @@
 package goorm.saerojinro.common.exception;
 
+import static goorm.saerojinro.common.exception.GlobalExceptionCode.FORBIDDEN;
 import static goorm.saerojinro.common.exception.GlobalExceptionCode.INVALID_INPUT;
 import static goorm.saerojinro.common.exception.GlobalExceptionCode.SERVER_ERROR;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import javax.naming.AuthenticationException;
 
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.context.ApplicationEventPublisher;
@@ -12,6 +15,7 @@ import org.springframework.context.MessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.method.ParameterValidationResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -41,6 +45,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	protected ResponseEntity<ExceptionResponse> handleException(Exception exception) {
 		eventPublisher.publishEvent(exception);
 		return ResponseEntity.internalServerError().body(ExceptionResponse.from(SERVER_ERROR));
+	}
+
+	@ExceptionHandler(AuthorizationDeniedException.class)
+	protected ResponseEntity<ExceptionResponse> handleAuthenticationException(AuthenticationException exception) {
+		eventPublisher.publishEvent(exception);
+		ExceptionResponse response = ExceptionResponse.from(FORBIDDEN);
+		return ResponseEntity.status(response.status()).body(response);
 	}
 
 	@Override


### PR DESCRIPTION
## ⚡️ 관련 이슈
> 관련 있는 이슈를 태그해주세요.
- #174 

## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.
- reissue는 모든 사용자 접근 가능으로 변경
  - Attendee로만 설정 시 만료된 토큰의 유저는 expired 예외로 처리되기 때문에 전체 허용으로 설정했습니다.
- logout의 User는 Attendee로 수정

## 🗣To Reviewer
> 의논이나 고려해야하는 내용을 작성해 주세요.
- reissue는 Attendee 접근가능으로만 설정 시 만료된 토큰의 유저는 expired 예외로 처리되기 때문에 전체 허용으로 설정했습니다.
